### PR TITLE
add option to configure number of streaming threads

### DIFF
--- a/src/main/java/org/infai/seits/sepl/operators/Stream.java
+++ b/src/main/java/org/infai/seits/sepl/operators/Stream.java
@@ -77,6 +77,7 @@ public class Stream {
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsConfiguration.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
+        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, Helper.getEnv("STREAM_THREADS_CONFIG", "1"));
 
         return streamsConfiguration;
     }


### PR DESCRIPTION
Altough scaling can be achieved by simple running more instances of the application, we can just as well increase the number of threads in each instance to understand if there is a difference in efficiency when reducing the JVM overhead.
This is implemented by simply setting the provided config to a value read from an environment variable. As it defaults to 1 when not set, it does not change the current behavior.

Provided tests have been run successfully.