### PR TITLE
return default config value if value is empty

### DIFF
--- a/src/main/java/org/infai/seits/sepl/operators/Config.java
+++ b/src/main/java/org/infai/seits/sepl/operators/Config.java
@@ -48,11 +48,16 @@ public class Config {
     }
 
     public String getConfigValue (String value, String defaultValue) {
+        String value = "";
         try {
-            return JsonPath.read(configString, "$.config."+value);
+            value = JsonPath.read(configString, "$.config."+value);
         } catch (PathNotFoundException e) {
             return defaultValue;
         }
+        if (value.length() == 0) {
+            return defaultValue;
+        }
+        return value;
     }
 
     public String getTopicName(Integer index){


### PR DESCRIPTION
Currently we only return the default value if the config can't be found at all. When configuring via the UI the value "" will be set if nothing is entered.
With this PR we would return the default value in this case.