### PR TITLE
Allow more than two streams/filters

### DIFF
--- a/src/main/java/org/infai/seits/sepl/operators/Builder.java
+++ b/src/main/java/org/infai/seits/sepl/operators/Builder.java
@@ -140,16 +140,7 @@ public class Builder {
     public JSONObject formatMessage(List<String> values){
         JSONObject ob = createMessageWrapper();
         JSONArray inputs = new JSONArray();
-
-        for(String value : values){
-            String[] split = value.split("},");
-            for(String splitValue : split){
-                if(!splitValue.endsWith("}")){
-                    splitValue += "}"; //'}' got removed by split if not last entry
-                }
-                inputs.put(new JSONObject(splitValue));
-            }
-        }
+        values.forEach((v) -> inputs.put(new JSONObject(v)));
         ob.put("inputs", inputs);
         return ob;
     }

--- a/src/main/java/org/infai/seits/sepl/operators/Builder.java
+++ b/src/main/java/org/infai/seits/sepl/operators/Builder.java
@@ -100,7 +100,21 @@ public class Builder {
             if(i == streams.length - 1) {
                 joinedStream = joinedStream.join(streams[i], (leftValue, rightValue) -> {
                             List<String> values = Arrays.asList(leftValue, rightValue);
-                            return formatMessage(values).toString();
+
+                            JSONObject ob = createMessageWrapper();
+                            JSONArray inputs = new JSONArray();
+
+                            for(String value : values){
+                                String[] split = value.split("},");
+                                for(String splitValue : split){
+                                    if(!splitValue.endsWith("}")){
+                                        splitValue += "}"; //'}' got removed by split if not last entry
+                                    }
+                                    inputs.put(new JSONObject(splitValue));
+                                }
+                            }
+                            ob.put("inputs", inputs);
+                            return ob.toString();
                         }, JoinWindows.of(TimeUnit.SECONDS.toMillis(seconds)), Joined.with(Serdes.String(), Serdes.String(), Serdes.String())
                 );
             }

--- a/src/main/java/org/infai/seits/sepl/operators/Builder.java
+++ b/src/main/java/org/infai/seits/sepl/operators/Builder.java
@@ -90,6 +90,30 @@ public class Builder {
         return joinedStream;
     }
 
+    public KStream<String, String> joinMultipleStreams(KStream[] streams) {
+        return joinMultipleStreams(streams, seconds);
+    }
+
+    public KStream<String, String> joinMultipleStreams(KStream[] streams, int seconds) {
+        KStream<String, String> joinedStream = streams[0];
+        for(int i = 1; i < streams.length; i++) {
+            if(i == streams.length - 1) {
+                joinedStream = joinedStream.join(streams[i], (leftValue, rightValue) -> {
+                            List<String> values = Arrays.asList(leftValue, rightValue);
+                            return formatMessage(values).toString();
+                        }, JoinWindows.of(TimeUnit.SECONDS.toMillis(seconds)), Joined.with(Serdes.String(), Serdes.String(), Serdes.String())
+                );
+            }
+            else {
+                joinedStream = joinedStream.join(streams[i], (leftValue, rightValue) -> leftValue +","+ rightValue,
+                        JoinWindows.of(TimeUnit.SECONDS.toMillis(seconds)), Joined.with(Serdes.String(), Serdes.String(), Serdes.String())
+                );
+            }
+        }
+
+        return joinedStream;
+    }
+
     public StreamsBuilder getBuilder() {
         return builder;
     }
@@ -116,7 +140,16 @@ public class Builder {
     public JSONObject formatMessage(List<String> values){
         JSONObject ob = createMessageWrapper();
         JSONArray inputs = new JSONArray();
-        values.forEach((v) -> inputs.put(new JSONObject(v)));
+
+        for(String value : values){
+            String[] split = value.split("},");
+            for(String splitValue : split){
+                if(!splitValue.endsWith("}")){
+                    splitValue += "}"; //'}' got removed by split if not last entry
+                }
+                inputs.put(new JSONObject(splitValue));
+            }
+        }
         ob.put("inputs", inputs);
         return ob;
     }


### PR DESCRIPTION
In this PR the limitation of only two filters or input topics is lifted by implementing a new method Stream#processMultipleStreams which is based on the old Stream#processTwoStreams but allows for any number of topics.

The new methods also handles any number of filters on these topics without creating multiple inputStreams for the same topic, which makes the old function Stream#processSingleStream2Filter obsolete.

In order to join multiple streams without chaining the message wrapper multiple times, a new function Builder#joinMultipleStreams gets introduced. 

A test for 2, 5 and 128 inputTopics was added. All old tests were run successfully.